### PR TITLE
fix OIDataFile ID uniqueness in OIDataFile Collection

### DIFF
--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/AxisEditor.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/AxisEditor.java
@@ -125,7 +125,7 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
     @Override
     public void dispose() {
         if (logger.isDebugEnabled()) {
-            logger.debug("AxisEditor[{}]: dispose", axisToEdit.getName());
+            logger.debug("AxisEditor[{}]: dispose", axisToEdit == null ? null : axisToEdit.getName());
         }
         reset();
     }

--- a/src/main/java/fr/jmmc/oiexplorer/core/model/OIFitsCollectionManager.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/model/OIFitsCollectionManager.java
@@ -547,28 +547,27 @@ public final class OIFitsCollectionManager implements OIFitsCollectionManagerEve
 
                 String id = StringUtils.replaceNonAlphaNumericCharsByUnderscore(oiFitsFile.getFileName());
 
-                // make it unique with a _bisN suffix
+                // make the id unique with a _bisN suffix
+                final String idSuffix = "_bis";
+
                 while (Identifiable.hasIdentifiable(id, getOIDataFileList())) {
-                    int index = id.lastIndexOf("_bis");
-                    if (index == -1) {
-                        id += "_bis1";
-                    } else {
-                        String strNumber = id.substring(index + 4);
+                    int index = id.lastIndexOf(idSuffix);
+                    int number = 1;
+                    if (index != -1) {
+                        String strNumber = id.substring(index + idSuffix.length());
+                        id = id.substring(0, index);
                         try {
-                            int number = Integer.decode(strNumber);
+                            number = Integer.parseInt(strNumber);
                             number++;
-                            id = id.substring(0, index);
-                            id += "_bis" + number;
-                        } catch (NumberFormatException e) {
-                            id += "_bis1";
+                        } catch (NumberFormatException nfe) {
+                            logger.debug("Unable to parse '{}'", strNumber);
                         }
                     }
+                    id += idSuffix + number;
                 }
 
                 dataFile.setId(id);
-
                 dataFile.setName(oiFitsFile.getFileName());
-
                 dataFile.setFile(oiFitsFile.getAbsoluteFilePath());
                 // checksum !
 

--- a/src/main/java/fr/jmmc/oiexplorer/core/model/OIFitsCollectionManager.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/model/OIFitsCollectionManager.java
@@ -545,9 +545,22 @@ public final class OIFitsCollectionManager implements OIFitsCollectionManagerEve
 
                 String id = StringUtils.replaceNonAlphaNumericCharsByUnderscore(oiFitsFile.getFileName());
 
-                // TODO: make it unique in a better way (this one can aggregate "_bis" suffixes)
+                // make it unique with a _bisN suffix
                 while (Identifiable.hasIdentifiable(id, getOIDataFileList())) {
-                    id += "_bis";
+                    int index = id.lastIndexOf("_bis");
+                    if (index == -1) {
+                        id += "_bis1";
+                    } else {
+                        String strNumber = id.substring(index + 4);
+                        try {
+                            int number = Integer.decode(strNumber);
+                            number++;
+                            id = id.substring(0, index);
+                            id += "_bis" + number;
+                        } catch (NumberFormatException e) {
+                            id += "_bis1";
+                        }
+                    }
                 }
 
                 dataFile.setId(id);

--- a/src/main/java/fr/jmmc/oiexplorer/core/model/OIFitsCollectionManager.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/model/OIFitsCollectionManager.java
@@ -543,9 +543,13 @@ public final class OIFitsCollectionManager implements OIFitsCollectionManagerEve
                 // Add new OIDataFile in collection
                 final OIDataFile dataFile = new OIDataFile();
 
-                final String id = StringUtils.replaceNonAlphaNumericCharsByUnderscore(oiFitsFile.getFileName());
+                String id = StringUtils.replaceNonAlphaNumericCharsByUnderscore(oiFitsFile.getFileName());
 
-                // TODO: make it unique !!
+                // TODO: make it unique in a better way (this one can aggregate "_bis" suffixes)
+                while (Identifiable.hasIdentifiable(id, getOIDataFileList())) {
+                    id += "_bis";
+                }
+
                 dataFile.setId(id);
 
                 dataFile.setName(oiFitsFile.getFileName());


### PR DESCRIPTION
PR associated to this issue https://github.com/JMMC-OpenDev/oimaging/issues/81

It was possible than two OImaging ViewerPanel have associated OIfitsFile with same filename.

This PR kind of fix the uniqueness of the filenames (btw there was a TODO asking to do it).

The fix is simplist. In case it becomes cumbersome (add suffixes too often), a better suffix function would be needed.

edit: 
- added a better suffix: _bisN instead of _bis_bis_bis.. https://github.com/JMMC-OpenDev/oiexplorer-core/pull/9/commits/ededa9cfde8f9a053a053cc8a85cbe1cb8dc6329
- corrected a trivial NullPointerException https://github.com/JMMC-OpenDev/oiexplorer-core/pull/9/commits/dd324085d892c4e0de0f1b934e33289284c7867f