### PR TITLE
created RangeEditor out of AxisEditor

### DIFF
--- a/src/main/java/fr/jmmc/oiexplorer/core/function/Converter.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/function/Converter.java
@@ -10,11 +10,18 @@ package fr.jmmc.oiexplorer.core.function;
 public interface Converter {
 
     /**
-     * Compute an output value given one input value
+     * Compute an output value given an input value
      * @param value input value
      * @return output value
      */
     public double evaluate(final double value);
+
+    /**
+     * Compute an input value given an output value
+     * @param value input value
+     * @return output value
+     */
+    public double invert(final double value);
 
     /**
      * Return the optional unit label

--- a/src/main/java/fr/jmmc/oiexplorer/core/function/ConverterFactory.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/function/ConverterFactory.java
@@ -27,6 +27,8 @@ public final class ConverterFactory {
     public final static Converter CONVERTER_MEGA_LAMBDA = new ScalingConverter(1e-6d, SpecialChars.UNIT_MEGA_LAMBDA);
     /** meter to micro meter converter to convert wave lengths */
     public final static Converter CONVERTER_MICRO_METER = new ScalingConverter(1e6d, SpecialChars.UNIT_MICRO_METER);
+    /** micro meter to meter converter, inverse of CONVERTER_MICRO_METER */
+    public final static Converter INV_CONVERTER_MICRO_METER = new ScalingConverter(1e-6d, "m");
     /** Reflection converter (opposite sign) */
     public final static Converter CONVERTER_REFLECT = new ReflectConverter();
     /* converter keys */
@@ -43,6 +45,8 @@ public final class ConverterFactory {
     /* TODO: load configuration from XML file ?? */
     /** predefined converters */
     private final Map<String, Converter> converters = new LinkedHashMap<String, Converter>(4);
+    /** inverse of predefined converters */
+    private final Map<String, Converter> inverseConverters = new LinkedHashMap<String, Converter>(1);
     /** predefined converters by column names */
     private final Map<String, String> converterByColumns = new HashMap<String, String>(16);
 
@@ -74,6 +78,9 @@ public final class ConverterFactory {
         converters.put(KEY_MEGA_LAMBDA, CONVERTER_MEGA_LAMBDA);
         converters.put(KEY_MICRO_METER, CONVERTER_MICRO_METER);
 
+        // create inverse converters:
+        inverseConverters.put(KEY_MICRO_METER, INV_CONVERTER_MICRO_METER);
+
         // associate converters to columns by default:
         converterByColumns.put(OIFitsConstants.COLUMN_EFF_WAVE, KEY_MICRO_METER);
         converterByColumns.put(OIFitsConstants.COLUMN_SPATIAL_FREQ, KEY_MEGA_LAMBDA);
@@ -83,6 +90,7 @@ public final class ConverterFactory {
         converterByColumns.put(OIFitsConstants.COLUMN_V1COORD_SPATIAL, KEY_MEGA_LAMBDA);
         converterByColumns.put(OIFitsConstants.COLUMN_U2COORD_SPATIAL, KEY_MEGA_LAMBDA);
         converterByColumns.put(OIFitsConstants.COLUMN_V2COORD_SPATIAL, KEY_MEGA_LAMBDA);
+
     }
 
     /** 
@@ -105,6 +113,23 @@ public final class ConverterFactory {
         final Converter converter = converters.get(name);
         if (converter == null) {
             throw new IllegalArgumentException("Converter [" + name + "] not found !");
+        }
+        return converter;
+    }
+
+    /**
+     * Get the inverse converter given to its name.
+     *
+     * @param name name to look for
+     * @return Inverse Converter associated to given name.
+     */
+    public Converter getInverseDefault(final String name) {
+        if (name == null || name.length() == 0) {
+            return null;
+        }
+        final Converter converter = inverseConverters.get(name);
+        if (converter == null) {
+            throw new IllegalArgumentException("Inverse Converter [" + name + "] not found !");
         }
         return converter;
     }

--- a/src/main/java/fr/jmmc/oiexplorer/core/function/ConverterFactory.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/function/ConverterFactory.java
@@ -27,8 +27,6 @@ public final class ConverterFactory {
     public final static Converter CONVERTER_MEGA_LAMBDA = new ScalingConverter(1e-6d, SpecialChars.UNIT_MEGA_LAMBDA);
     /** meter to micro meter converter to convert wave lengths */
     public final static Converter CONVERTER_MICRO_METER = new ScalingConverter(1e6d, SpecialChars.UNIT_MICRO_METER);
-    /** micro meter to meter converter, inverse of CONVERTER_MICRO_METER */
-    public final static Converter INV_CONVERTER_MICRO_METER = new ScalingConverter(1e-6d, "m");
     /** Reflection converter (opposite sign) */
     public final static Converter CONVERTER_REFLECT = new ReflectConverter();
     /* converter keys */
@@ -45,8 +43,6 @@ public final class ConverterFactory {
     /* TODO: load configuration from XML file ?? */
     /** predefined converters */
     private final Map<String, Converter> converters = new LinkedHashMap<String, Converter>(4);
-    /** inverse of predefined converters */
-    private final Map<String, Converter> inverseConverters = new LinkedHashMap<String, Converter>(1);
     /** predefined converters by column names */
     private final Map<String, String> converterByColumns = new HashMap<String, String>(16);
 
@@ -78,9 +74,6 @@ public final class ConverterFactory {
         converters.put(KEY_MEGA_LAMBDA, CONVERTER_MEGA_LAMBDA);
         converters.put(KEY_MICRO_METER, CONVERTER_MICRO_METER);
 
-        // create inverse converters:
-        inverseConverters.put(KEY_MICRO_METER, INV_CONVERTER_MICRO_METER);
-
         // associate converters to columns by default:
         converterByColumns.put(OIFitsConstants.COLUMN_EFF_WAVE, KEY_MICRO_METER);
         converterByColumns.put(OIFitsConstants.COLUMN_SPATIAL_FREQ, KEY_MEGA_LAMBDA);
@@ -90,7 +83,6 @@ public final class ConverterFactory {
         converterByColumns.put(OIFitsConstants.COLUMN_V1COORD_SPATIAL, KEY_MEGA_LAMBDA);
         converterByColumns.put(OIFitsConstants.COLUMN_U2COORD_SPATIAL, KEY_MEGA_LAMBDA);
         converterByColumns.put(OIFitsConstants.COLUMN_V2COORD_SPATIAL, KEY_MEGA_LAMBDA);
-
     }
 
     /** 
@@ -113,23 +105,6 @@ public final class ConverterFactory {
         final Converter converter = converters.get(name);
         if (converter == null) {
             throw new IllegalArgumentException("Converter [" + name + "] not found !");
-        }
-        return converter;
-    }
-
-    /**
-     * Get the inverse converter given to its name.
-     *
-     * @param name name to look for
-     * @return Inverse Converter associated to given name.
-     */
-    public Converter getInverseDefault(final String name) {
-        if (name == null || name.length() == 0) {
-            return null;
-        }
-        final Converter converter = inverseConverters.get(name);
-        if (converter == null) {
-            throw new IllegalArgumentException("Inverse Converter [" + name + "] not found !");
         }
         return converter;
     }

--- a/src/main/java/fr/jmmc/oiexplorer/core/function/LinearConverter.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/function/LinearConverter.java
@@ -30,7 +30,7 @@ public final class LinearConverter implements Converter {
     }
 
     /**
-     * Compute an output value given one input value using:
+     * Compute an output value given an input value using:
      * y = a.x + b
      * @param value input value (x)
      * @return output value (y)
@@ -38,6 +38,17 @@ public final class LinearConverter implements Converter {
     @Override
     public double evaluate(final double value) {
         return scalingFactor * value + constant;
+    }
+
+    /**
+     * Compute an input value given an output value using:
+     * y = a.x + b <=> x = (y - b)/a
+     * @param value output value (y)
+     * @return input value (x)
+     */
+    @Override
+    public double invert(final double value) {
+        return (value - constant) / scalingFactor;
     }
 
     /**

--- a/src/main/java/fr/jmmc/oiexplorer/core/function/ReflectConverter.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/function/ReflectConverter.java
@@ -10,13 +10,24 @@ package fr.jmmc.oiexplorer.core.function;
 public final class ReflectConverter implements Converter {
 
     /**
-     * Compute an output value given one input value using:
+     * Compute an output value given an input value using:
      * y = -x
      * @param value input value (x)
      * @return output value (y)
      */
     @Override
     public double evaluate(final double value) {
+        return -value;
+    }
+
+    /**
+     * Compute an input value given an output value using:
+     * y = -x <=> x = -y
+     * @param value output value (y)
+     * @return input value (x)
+     */
+    @Override
+    public double invert(final double value) {
         return -value;
     }
 

--- a/src/main/java/fr/jmmc/oiexplorer/core/function/ScalingConverter.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/function/ScalingConverter.java
@@ -26,7 +26,7 @@ public final class ScalingConverter implements Converter {
     }
 
     /**
-     * Compute an output value given one input value using:
+     * Compute an output value given an input value using:
      * y = a.x
      * @param value input value (x)
      * @return output value (y)
@@ -34,6 +34,17 @@ public final class ScalingConverter implements Converter {
     @Override
     public double evaluate(final double value) {
         return scalingFactor * value;
+    }
+
+    /**
+     * Compute an input value given an output value using:
+     * y = a.x <=> x = (1/a).y
+     * @param value output value (y)
+     * @return input value (x)
+     */
+    @Override
+    public double invert(final double value) {
+        return value / scalingFactor;
     }
 
     /**

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/AxisEditor.form
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/AxisEditor.form
@@ -31,7 +31,7 @@
       </Events>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.8" weightY="0.0"/>
+          <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.6" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -78,7 +78,7 @@
     <Container class="javax.swing.JPanel" name="jPanelBounds">
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="4" gridY="0" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="2" insetsBottom="0" insetsRight="2" anchor="10" weightX="0.2" weightY="0.0"/>
+          <GridBagConstraints gridX="4" gridY="0" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="2" insetsBottom="0" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
 
@@ -133,66 +133,14 @@
             </Constraint>
           </Constraints>
         </Component>
-        <Component class="javax.swing.JFormattedTextField" name="jFieldMin">
-          <Properties>
-            <Property name="columns" type="int" value="4"/>
-            <Property name="formatterFactory" type="javax.swing.JFormattedTextField$AbstractFormatterFactory" editor="org.netbeans.modules.form.editors.AbstractFormatterFactoryEditor">
-              <Format format="###0.####" subtype="-1" type="0"/>
-            </Property>
-          </Properties>
-          <Events>
-            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="actionPerformed"/>
-          </Events>
-          <AuxValues>
-            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new JFormattedTextField(getNumberFieldFormatter())"/>
-          </AuxValues>
-          <Constraints>
-            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-              <GridBagConstraints gridX="3" gridY="0" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="2" anchor="10" weightX="0.2" weightY="0.0"/>
-            </Constraint>
-          </Constraints>
-        </Component>
-        <Component class="javax.swing.JFormattedTextField" name="jFieldMax">
-          <Properties>
-            <Property name="columns" type="int" value="4"/>
-            <Property name="formatterFactory" type="javax.swing.JFormattedTextField$AbstractFormatterFactory" editor="org.netbeans.modules.form.editors.AbstractFormatterFactoryEditor">
-              <Format format="###0.####" subtype="-1" type="0"/>
-            </Property>
-          </Properties>
-          <Events>
-            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="actionPerformed"/>
-          </Events>
-          <AuxValues>
-            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new JFormattedTextField(getNumberFieldFormatter())"/>
-          </AuxValues>
-          <Constraints>
-            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-              <GridBagConstraints gridX="4" gridY="0" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.2" weightY="0.0"/>
-            </Constraint>
-          </Constraints>
-        </Component>
-        <Component class="javax.swing.JComboBox" name="rangeListComboBox">
-          <Properties>
-            <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
-              <StringArray count="0"/>
-            </Property>
-            <Property name="prototypeDisplayValue" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-              <Connection code="&quot;XXXX&quot;" type="code"/>
-            </Property>
-          </Properties>
-          <Events>
-            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="rangeListComboBoxActionPerformed"/>
-          </Events>
-          <AuxValues>
-            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value=""/>
-          </AuxValues>
-          <Constraints>
-            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-              <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.2" weightY="0.0"/>
-            </Constraint>
-          </Constraints>
-        </Component>
       </SubComponents>
     </Container>
+    <Component class="fr.jmmc.oiexplorer.core.gui.RangeEditor" name="rangeEditor">
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="5" gridY="0" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="2" insetsBottom="0" insetsRight="2" anchor="10" weightX="0.2" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
   </SubComponents>
 </Form>

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/AxisEditor.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/AxisEditor.java
@@ -104,7 +104,8 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable, Change
         nameComboBoxModel.clear();
 
         if (axis == null) {
-            rangeEditor.setRange(null, null, null);
+            rangeEditor.setAlias(null);
+            rangeEditor.setRange(null);
             return;
         }
         try {
@@ -118,7 +119,8 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable, Change
             logScaleCheckBox.setSelected(axis.isLogScale());
             includeDataRangeCheckBox.setSelected(axis.isIncludeDataRangeOrDefault());
 
-            rangeEditor.setRange(axis.getRange(), axisName + ".min", axisName + ".max");
+            rangeEditor.setAlias(axisName);
+            rangeEditor.setRange(axis.getRange());
 
             // enable or disable popup menus:
             updateRangeEditor(axis.getRange(), axis.getRangeModeOrDefault(), true);
@@ -163,7 +165,8 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable, Change
                 r.setMax(Double.NaN);
             }
             axisToEdit.setRange(r);
-            rangeEditor.setRange(r, axisToEdit.getName() + ".min", axisToEdit.getName() + ".max");
+            rangeEditor.setAlias(axisToEdit.getName());
+            rangeEditor.setRange(r);
         }
         updateRangeEditor(axisToEdit.getRange(), axisToEdit.getRangeMode());
         updateRangeList();

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/AxisEditor.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/AxisEditor.java
@@ -126,8 +126,7 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable, Change
             updateRangeEditor(axis.getRange(), axis.getRangeModeOrDefault(), true);
             updateRangeList();
 
-        }
-        finally {
+        } finally {
             notify = true;
         }
     }
@@ -191,7 +190,7 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable, Change
         }
         final boolean enable = (mode == AxisRangeMode.RANGE);
         rangeEditor.setEnabled(enable);
-        rangeEditor.updateRangeEditor(range, setRange);
+        rangeEditor.updateRange(range, setRange);
     }
 
     /** 
@@ -204,8 +203,8 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable, Change
 
     @Override
     public void stateChanged(ChangeEvent ce) {
-        if (ce.getSource() instanceof RangeEditor) {
-            if (notify) {
+        if (notify) {
+            if (ce.getSource() instanceof RangeEditor) {
                 parentToNotify.updateModel(false); // false: no need to refresh plot definition names
             }
         }

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/AxisEditor.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/AxisEditor.java
@@ -15,6 +15,8 @@ import java.awt.Font;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.JComponent;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,7 +25,7 @@ import org.slf4j.LoggerFactory;
  * 
  * @author mella
  */
-public class AxisEditor extends javax.swing.JPanel implements Disposable, RangeEditor.UpdateListener {
+public class AxisEditor extends javax.swing.JPanel implements Disposable, ChangeListener {
 
     /** default serial UID for Serializable interface */
     private static final long serialVersionUID = 1L;
@@ -51,6 +53,8 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable, RangeE
         parentToNotify = parent;
         nameComboBoxModel = new GenericListModel<String>(new ArrayList<String>(25), true);
         nameComboBox.setModel(nameComboBoxModel);
+
+        rangeEditor.addChangeListener(this);
 
         // hidden until request and valid code to get a correct behaviour
         final JComponent[] components = new JComponent[]{
@@ -101,7 +105,6 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable, RangeE
 
         if (axis == null) {
             rangeEditor.setRange(null, null, null);
-            rangeEditor.setUpdateListener(null);
             return;
         }
         try {
@@ -116,7 +119,6 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable, RangeE
             includeDataRangeCheckBox.setSelected(axis.isIncludeDataRangeOrDefault());
 
             rangeEditor.setRange(axis.getRange(), axisName + ".min", axisName + ".max");
-            rangeEditor.setUpdateListener(this);
 
             // enable or disable popup menus:
             updateRangeEditor(axis.getRange(), axis.getRangeModeOrDefault(), true);
@@ -198,9 +200,11 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable, RangeE
     }
 
     @Override
-    public void rangeEditorUpdated() {
-        if (notify) {
-            parentToNotify.updateModel(false); // false: no need to refresh plot definition names
+    public void stateChanged(ChangeEvent ce) {
+        if (ce.getSource() instanceof RangeEditor) {
+            if (notify) {
+                parentToNotify.updateModel(false); // false: no need to refresh plot definition names
+            }
         }
     }
 

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/AxisEditor.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/AxisEditor.java
@@ -3,28 +3,18 @@
  ******************************************************************************/
 package fr.jmmc.oiexplorer.core.gui;
 
-import fr.jmmc.jmal.AbsorptionLineRange;
 import fr.jmmc.jmcs.gui.component.Disposable;
 import fr.jmmc.jmcs.gui.component.GenericListModel;
 import fr.jmmc.jmcs.gui.util.SwingUtils;
-import fr.jmmc.jmcs.service.RecentValuesManager;
-import fr.jmmc.jmcs.util.ObjectUtils;
 import fr.jmmc.oiexplorer.core.function.ConverterFactory;
 import fr.jmmc.oiexplorer.core.model.plot.Axis;
 import fr.jmmc.oiexplorer.core.model.plot.AxisRangeMode;
 import fr.jmmc.oiexplorer.core.model.plot.Range;
 import fr.jmmc.oitools.OIFitsConstants;
 import java.awt.Font;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.text.DecimalFormat;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.JComponent;
-import javax.swing.JFormattedTextField;
-import javax.swing.JPopupMenu;
-import javax.swing.text.NumberFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,14 +23,12 @@ import org.slf4j.LoggerFactory;
  * 
  * @author mella
  */
-public class AxisEditor extends javax.swing.JPanel implements Disposable {
+public class AxisEditor extends javax.swing.JPanel implements Disposable, RangeEditor.UpdateListener {
 
     /** default serial UID for Serializable interface */
     private static final long serialVersionUID = 1L;
     /** Logger */
     private static final Logger logger = LoggerFactory.getLogger(AxisEditor.class.getName());
-    /** undefined value for range list */
-    private static final String RANGE_NONE = "[None]";
 
     /* members */
     /** PlotDefinitionEditor to notify in case of modification */
@@ -49,21 +37,8 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
     private Axis axisToEdit;
     /** List of available axis names */
     private final GenericListModel<String> nameComboBoxModel;
-    /** List of possible ranges for the axis */
-    private final GenericListModel<String> rangeComboBoxModel;
     /** Flag notification of associated plotDefinitionEditor */
     private boolean notify = true;
-    /** Flag indicating a user input */
-    private boolean user_input = true;
-    // recent values keys for min/max:
-    private String keyMin = null;
-    private String keyMax = null;
-    // listener references (alive until this editor is dead or axis changes):
-    private ActionListener popupListenerMin = null;
-    private ActionListener popupListenerMax = null;
-    // popup menus in action (alive until this editor is dead or axis changes):
-    private JPopupMenu popupMenuMin = null;
-    private JPopupMenu popupMenuMax = null;
 
     /** 
      * Creates the new AxisEditor form.
@@ -77,34 +52,13 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
         nameComboBoxModel = new GenericListModel<String>(new ArrayList<String>(25), true);
         nameComboBox.setModel(nameComboBoxModel);
 
-        rangeComboBoxModel = new GenericListModel<String>(new ArrayList<String>(10), true);
-        rangeListComboBox.setModel(rangeComboBoxModel);
-
         // hidden until request and valid code to get a correct behaviour
         final JComponent[] components = new JComponent[]{
-            includeZeroCheckBox, includeDataRangeCheckBox, jRadioModeAuto, jRadioModeDefault, jRadioModeFixed, jFieldMin, jFieldMax
+            includeZeroCheckBox, includeDataRangeCheckBox, jRadioModeAuto, jRadioModeDefault, jRadioModeFixed
         };
         for (JComponent c : components) {
             c.setVisible(c.isEnabled());
         }
-
-        jFieldMin.addPropertyChangeListener("value", new java.beans.PropertyChangeListener() {
-            @Override
-            public void propertyChange(java.beans.PropertyChangeEvent evt) {
-                if (!ObjectUtils.areEquals(evt.getOldValue(), evt.getNewValue())) {
-                    actionPerformed(new ActionEvent(jFieldMin, 0, ""));
-                }
-            }
-        });
-
-        jFieldMax.addPropertyChangeListener("value", new java.beans.PropertyChangeListener() {
-            @Override
-            public void propertyChange(java.beans.PropertyChangeEvent evt) {
-                if (!ObjectUtils.areEquals(evt.getOldValue(), evt.getNewValue())) {
-                    actionPerformed(new ActionEvent(jFieldMax, 0, ""));
-                }
-            }
-        });
 
         // Adjust fonts:
         final Font fixedFont = new Font(Font.MONOSPACED, Font.PLAIN, SwingUtils.adjustUISize(12));
@@ -128,6 +82,7 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
             logger.debug("AxisEditor[{}]: dispose", axisToEdit == null ? null : axisToEdit.getName());
         }
         reset();
+        rangeEditor.dispose();
     }
 
     public void reset() {
@@ -145,17 +100,12 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
         nameComboBoxModel.clear();
 
         if (axis == null) {
-            // reset state
-            keyMin = keyMax = null;
-            // dispose popup menus:
-            jFieldMin.setComponentPopupMenu(null);
-            jFieldMax.setComponentPopupMenu(null);
-            popupListenerMin = popupListenerMax = null;
-            popupMenuMin = popupMenuMax = null;
+            rangeEditor.setRange(null, null, null);
+            rangeEditor.setUpdateListener(null);
             return;
         }
         try {
-            notify = user_input = false;
+            notify = false;
             final String axisName = axis.getName();
 
             nameComboBoxModel.add(axisChoices);
@@ -165,49 +115,22 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
             logScaleCheckBox.setSelected(axis.isLogScale());
             includeDataRangeCheckBox.setSelected(axis.isIncludeDataRangeOrDefault());
 
-            // Add popup menus to min/max fields:
-            keyMin = axisName + ".min";
-            keyMax = axisName + ".max";
-
-            // create new listeners to release previous listeners / popup menus:
-            popupListenerMin = new FieldSetter(jFieldMin);
-            popupListenerMax = new FieldSetter(jFieldMax);
-
-            popupMenuMin = RecentValuesManager.getMenu(keyMin, popupListenerMin);
-            popupMenuMax = RecentValuesManager.getMenu(keyMax, popupListenerMax);
+            rangeEditor.setRange(axis.getRange(), axisName + ".min", axisName + ".max");
+            rangeEditor.setUpdateListener(this);
 
             // enable or disable popup menus:
             updateRangeEditor(axis.getRange(), axis.getRangeModeOrDefault(), true);
             updateRangeList();
 
-        } finally {
-            notify = user_input = true;
+        }
+        finally {
+            notify = true;
         }
     }
 
     public boolean setAxisRange(final double min, final double max) {
         logger.debug("setAxisRange: [{} - {}]", min, max);
-
-        boolean changed = false;
-        try {
-            notify = user_input = false;
-
-            changed |= setFieldValue(jFieldMin, min);
-            changed |= setFieldValue(jFieldMax, max);
-        } finally {
-            notify = user_input = true;
-        }
-        return changed;
-    }
-
-    private boolean setFieldValue(final JFormattedTextField field, final double value) {
-        final Object newValue = Double.valueOf(value);
-        final Object prev = field.getValue();
-        if (ObjectUtils.areEquals(prev, newValue)) {
-            return false;
-        }
-        field.setValue(newValue);
-        return true;
+        return rangeEditor.setRangeFieldValues(min, max);
     }
 
     private void updateRangeList() {
@@ -215,46 +138,9 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
 
         // TODO: use a factory to get predefined ranges per column name ?
         if (isWavelengthAxis) {
-            rangeComboBoxModel.clear();
-            rangeComboBoxModel.add(RANGE_NONE); // empty
-            for (AbsorptionLineRange r : AbsorptionLineRange.values()) {
-                rangeComboBoxModel.add(r.getName());
-            }
-        }
-        rangeListComboBox.setVisible(isWavelengthAxis);
-    }
-
-    private void handleRangeListSelection() {
-        if (isWavelengthAxis()) {
-            final String selected = (String) rangeListComboBox.getSelectedItem();
-
-            double min = Double.NaN;
-            double max = Double.NaN;
-
-            if (!RANGE_NONE.equalsIgnoreCase(selected)) {
-                for (AbsorptionLineRange r : AbsorptionLineRange.values()) {
-                    if (r.getName().equals(selected)) {
-                        logger.debug("AbsorptionLineRange: {}", r);
-                        min = r.getMin();
-                        max = r.getMax();
-                        break;
-                    }
-                }
-            }
-
-            if (isFinite(min) || isFinite(max)) {
-                try {
-                    user_input = false;
-
-                    jFieldMin.setValue(Double.valueOf(min));
-                    jFieldMax.setValue(Double.valueOf(max));
-
-                    // switch this axis in Fixed mode:
-                    jRadioModeFixed.doClick();
-                } finally {
-                    user_input = true;
-                }
-            }
+            rangeEditor.updateRangeList(RangeEditor.EFF_WAVE_PREDEFINED_RANGES);
+        } else {
+            rangeEditor.updateRangeList(null);
         }
     }
 
@@ -267,10 +153,18 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
 
         if (mode == AxisRangeMode.RANGE) {
             // hack to initialize range from plot values:
-            final Range r = getFieldRange();
+            Range r = rangeEditor.getFieldRange();
+            // we must have a (NaN,Nan) Range to give to RangeEditor
+            if (r == null) {
+                r = new Range();
+                r.setMin(Double.NaN);
+                r.setMax(Double.NaN);
+            }
             axisToEdit.setRange(r);
+            rangeEditor.setRange(r, axisToEdit.getName() + ".min", axisToEdit.getName() + ".max");
         }
         updateRangeEditor(axisToEdit.getRange(), axisToEdit.getRangeMode());
+        updateRangeList();
     }
 
     private void updateRangeEditor(final Range range, final AxisRangeMode mode) {
@@ -278,15 +172,6 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
     }
 
     private void updateRangeEditor(final Range range, final AxisRangeMode mode, final boolean setRange) {
-        if (setRange) {
-            if (range == null) {
-                jFieldMin.setValue(null);
-                jFieldMax.setValue(null);
-            } else {
-                jFieldMin.setValue(isFinite(range.getMin()) ? Double.valueOf(range.getMin()) : null);
-                jFieldMax.setValue(isFinite(range.getMax()) ? Double.valueOf(range.getMax()) : null);
-            }
-        }
         switch (mode) {
             case AUTO:
                 jRadioModeAuto.setSelected(true);
@@ -300,62 +185,8 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
                 break;
         }
         final boolean enable = (mode == AxisRangeMode.RANGE);
-        jFieldMin.setEnabled(enable);
-        jFieldMax.setEnabled(enable);
-
-        // enable or disable popup menus:
-        enablePopupMenu(jFieldMin, popupMenuMin);
-        enablePopupMenu(jFieldMax, popupMenuMax);
-    }
-
-    private Range getFieldRange() {
-        double min = Double.NaN;
-        double max = Double.NaN;
-
-        Object value = this.jFieldMin.getValue();
-
-        if (value instanceof Double) {
-            min = ((Double) value).doubleValue();
-        }
-
-        value = this.jFieldMax.getValue();
-        if (value instanceof Double) {
-            max = ((Double) value).doubleValue();
-        }
-
-        final boolean minFinite = isFinite(min);
-        final boolean maxFinite = isFinite(max);
-
-        Range range = null;
-
-        if ((minFinite != maxFinite)
-                || (minFinite && maxFinite && (min < max))) {
-
-            range = new Range();
-            range.setMin(min);
-            range.setMax(max);
-        }
-
-        // Do not store values set programmatically:
-        if (user_input && jRadioModeFixed.isSelected()) {
-            // Update recent values:
-            if (keyMin != null) {
-                RecentValuesManager.addValue(keyMin, (minFinite) ? parseField(this.jFieldMin.getFormatter(), min) : null);
-            }
-            if (keyMax != null) {
-                RecentValuesManager.addValue(keyMax, (maxFinite) ? parseField(this.jFieldMax.getFormatter(), min) : null);
-            }
-        }
-        return range;
-    }
-
-    private static String parseField(final JFormattedTextField.AbstractFormatter fmt, final double value) {
-        try {
-            return fmt.valueToString(value);
-        } catch (ParseException pe) {
-            logger.info("parseField: value = {}", value, pe);
-        }
-        return Double.toString(value);
+        rangeEditor.setEnabled(enable);
+        rangeEditor.updateRangeEditor(range, setRange);
     }
 
     /** 
@@ -364,6 +195,13 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
      */
     public Axis getAxis() {
         return axisToEdit;
+    }
+
+    @Override
+    public void rangeEditorUpdated() {
+        if (notify) {
+            parentToNotify.updateModel(false); // false: no need to refresh plot definition names
+        }
     }
 
     /** This method is called from within the constructor to
@@ -385,9 +223,7 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
         jRadioModeAuto = new javax.swing.JRadioButton();
         jRadioModeDefault = new javax.swing.JRadioButton();
         jRadioModeFixed = new javax.swing.JRadioButton();
-        jFieldMin = new JFormattedTextField(getNumberFieldFormatter());
-        jFieldMax = new JFormattedTextField(getNumberFieldFormatter());
-        rangeListComboBox = new javax.swing.JComboBox();
+        rangeEditor = new fr.jmmc.oiexplorer.core.gui.RangeEditor();
 
         setLayout(new java.awt.GridBagLayout());
 
@@ -401,7 +237,7 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
-        gridBagConstraints.weightx = 0.8;
+        gridBagConstraints.weightx = 0.6;
         gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
         add(nameComboBox, gridBagConstraints);
 
@@ -478,52 +314,19 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
         gridBagConstraints.gridy = 0;
         jPanelBounds.add(jRadioModeFixed, gridBagConstraints);
 
-        jFieldMin.setColumns(4);
-        jFieldMin.setFormatterFactory(new javax.swing.text.DefaultFormatterFactory(new javax.swing.text.NumberFormatter(new java.text.DecimalFormat("###0.####"))));
-        jFieldMin.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                AxisEditor.this.actionPerformed(evt);
-            }
-        });
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 3;
-        gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
-        gridBagConstraints.weightx = 0.2;
-        gridBagConstraints.insets = new java.awt.Insets(0, 0, 0, 2);
-        jPanelBounds.add(jFieldMin, gridBagConstraints);
-
-        jFieldMax.setColumns(4);
-        jFieldMax.setFormatterFactory(new javax.swing.text.DefaultFormatterFactory(new javax.swing.text.NumberFormatter(new java.text.DecimalFormat("###0.####"))));
-        jFieldMax.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                AxisEditor.this.actionPerformed(evt);
-            }
-        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 4;
         gridBagConstraints.gridy = 0;
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
-        gridBagConstraints.weightx = 0.2;
-        jPanelBounds.add(jFieldMax, gridBagConstraints);
-
-        rangeListComboBox.setPrototypeDisplayValue("XXXX");
-        rangeListComboBox.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                rangeListComboBoxActionPerformed(evt);
-            }
-        });
+        gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 2);
+        add(jPanelBounds, gridBagConstraints);
         gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.weightx = 0.2;
-        jPanelBounds.add(rangeListComboBox, gridBagConstraints);
-
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 4;
+        gridBagConstraints.gridx = 5;
         gridBagConstraints.gridy = 0;
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
         gridBagConstraints.weightx = 0.2;
         gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 2);
-        add(jPanelBounds, gridBagConstraints);
+        add(rangeEditor, gridBagConstraints);
     }// </editor-fold>//GEN-END:initComponents
 
     private void actionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_actionPerformed
@@ -559,26 +362,6 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
             updateRangeMode(AxisRangeMode.DEFAULT);
         } else if (evt.getSource() == jRadioModeFixed) {
             updateRangeMode(AxisRangeMode.RANGE);
-        } else if (evt.getSource() == jFieldMin) {
-            // only update edited axis when the mode is RANGE ie Enabled:
-            if (jFieldMin.isEnabled()) {
-                final Range r = getFieldRange();
-                axisToEdit.setRange(r);
-                if (r == null) {
-                    jFieldMin.requestFocus();
-                }
-            }
-        } else if (evt.getSource() == jFieldMax) {
-            // only update edited axis when the mode is RANGE ie Enabled:
-            if (jFieldMax.isEnabled()) {
-                final Range r = getFieldRange();
-                axisToEdit.setRange(r);
-                if (r == null) {
-                    jFieldMax.requestFocus();
-                }
-            }
-        } else if (evt.getSource() == rangeListComboBox) {
-            handleRangeListSelection();
         } else {
             throw new IllegalStateException("TODO: handle event from " + evt.getSource());
         }
@@ -588,76 +371,16 @@ public class AxisEditor extends javax.swing.JPanel implements Disposable {
         }
     }//GEN-LAST:event_actionPerformed
 
-    private void rangeListComboBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_rangeListComboBoxActionPerformed
-        AxisEditor.this.actionPerformed(evt);
-    }//GEN-LAST:event_rangeListComboBoxActionPerformed
-
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.ButtonGroup buttonGroupRangeModes;
     private javax.swing.JCheckBox includeDataRangeCheckBox;
     private javax.swing.JCheckBox includeZeroCheckBox;
-    private javax.swing.JFormattedTextField jFieldMax;
-    private javax.swing.JFormattedTextField jFieldMin;
     private javax.swing.JPanel jPanelBounds;
     private javax.swing.JRadioButton jRadioModeAuto;
     private javax.swing.JRadioButton jRadioModeDefault;
     private javax.swing.JRadioButton jRadioModeFixed;
     private javax.swing.JCheckBox logScaleCheckBox;
     private javax.swing.JComboBox nameComboBox;
-    private javax.swing.JComboBox rangeListComboBox;
+    private fr.jmmc.oiexplorer.core.gui.RangeEditor rangeEditor;
     // End of variables declaration//GEN-END:variables
-
-    /**
-     * Return the custom double formatter that accepts null values
-     * @return number formatter
-     */
-    private static NumberFormatter getNumberFieldFormatter() {
-        final NumberFormatter nf = new NumberFormatter(new DecimalFormat("####.####")) {
-            /** default serial UID for Serializable interface */
-            private static final long serialVersionUID = 1;
-
-            /**
-             * Hack to allow empty string
-             */
-            @Override
-            public Object stringToValue(final String text) throws ParseException {
-                if (text == null || text.length() == 0) {
-                    return null;
-                }
-                return super.stringToValue(text);
-            }
-        };
-        nf.setValueClass(Double.class);
-        nf.setCommitsOnValidEdit(false);
-        return nf;
-    }
-
-    private static boolean isFinite(final double value) {
-        return !(Double.isNaN(value) && !Double.isInfinite(value));
-    }
-
-    private static final class FieldSetter implements ActionListener {
-
-        private final JFormattedTextField textField;
-
-        FieldSetter(final JFormattedTextField textField) {
-            this.textField = textField;
-        }
-
-        @Override
-        public void actionPerformed(final ActionEvent ae) {
-            final String value = ae.getActionCommand();
-            textField.setValue((value != null) ? Double.valueOf(value) : null);
-        }
-    }
-
-    private static void enablePopupMenu(final JComponent component, final JPopupMenu popupMenu) {
-        JPopupMenu enabledPopupMenu = null;
-        if (popupMenu != null) {
-            if (component.isEnabled() && popupMenu.getComponentCount() != 0) {
-                enabledPopupMenu = popupMenu;
-            }
-        }
-        component.setComponentPopupMenu(enabledPopupMenu);
-    }
 }

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/GenericFilterEditor.form
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/GenericFilterEditor.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<Form version="1.3" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
+<Form version="1.8" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
@@ -25,14 +25,14 @@
       </Events>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
     <Container class="javax.swing.JPanel" name="jPanelRangeEditors">
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="2" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="2" gridY="0" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.7" weightY="0.0"/>
         </Constraint>
       </Constraints>
 
@@ -56,7 +56,7 @@
       </AuxValues>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="1" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="1" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="17" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/GenericFilterEditor.form
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/GenericFilterEditor.form
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<Form version="1.3" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
+  <AuxValues>
+    <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
+    <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
+    <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_layoutCodeTarget" type="java.lang.Integer" value="1"/>
+    <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
+    <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,44,0,0,1,-112"/>
+  </AuxValues>
+
+  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
+  <SubComponents>
+    <Component class="javax.swing.JCheckBox" name="jCheckBoxEnabled">
+      <Properties>
+        <Property name="selected" type="boolean" value="true"/>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jCheckBoxEnabledActionPerformed"/>
+      </Events>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+    <Component class="javax.swing.JLabel" name="jLabelColumnName">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="COLUMN_NAME"/>
+      </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="1" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+    <Container class="javax.swing.JPanel" name="jPanelRangeEditors">
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="2" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout">
+        <Property name="axis" type="int" value="3"/>
+      </Layout>
+    </Container>
+  </SubComponents>
+</Form>

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/GenericFilterEditor.form
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/GenericFilterEditor.form
@@ -29,20 +29,10 @@
         </Constraint>
       </Constraints>
     </Component>
-    <Component class="javax.swing.JLabel" name="jLabelColumnName">
-      <Properties>
-        <Property name="text" type="java.lang.String" value="COLUMN_NAME"/>
-      </Properties>
-      <Constraints>
-        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="1" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
-        </Constraint>
-      </Constraints>
-    </Component>
     <Container class="javax.swing.JPanel" name="jPanelRangeEditors">
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="2" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="2" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
 
@@ -50,5 +40,25 @@
         <Property name="axis" type="int" value="3"/>
       </Layout>
     </Container>
+    <Component class="javax.swing.JComboBox" name="jComboBoxColumnName">
+      <Properties>
+        <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+          <StringArray count="1">
+            <StringItem index="0" value="COLUMN_NAME"/>
+          </StringArray>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jComboBoxColumnNameActionPerformed"/>
+      </Events>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+      </AuxValues>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="1" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
   </SubComponents>
 </Form>

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/GenericFilterEditor.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/GenericFilterEditor.java
@@ -1,0 +1,238 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/GUIForms/JPanel.java to edit this template
+ */
+package fr.jmmc.oiexplorer.core.gui;
+
+import fr.jmmc.jmcs.gui.component.Disposable;
+import fr.jmmc.oiexplorer.core.model.oi.DataType;
+import fr.jmmc.oiexplorer.core.model.oi.GenericFilter;
+import fr.jmmc.oiexplorer.core.model.plot.Range;
+import static fr.jmmc.oitools.OIFitsConstants.COLUMN_EFF_WAVE;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+/**
+ *
+ */
+public class GenericFilterEditor extends javax.swing.JPanel implements Disposable {
+
+    /**
+     * default serial UID for Serializable interface
+     */
+    private static final long serialVersionUID = 1;
+
+    /**
+     * Logger
+     */
+    //private static final Logger logger = LoggerFactory.getLogger(GenericFilterEditor.class);
+
+    private GenericFilter genericFilter;
+
+    private final List<RangeEditor> rangeEditors;
+
+    private final RangeEditorChangeListener rangeEditorChangeListener;
+
+    /**
+     * Creates new form GenericFilterEditor
+     */
+    public GenericFilterEditor() {
+        initComponents();
+        rangeEditors = new ArrayList<>();
+        rangeEditorChangeListener = new RangeEditorChangeListener();
+    }
+
+    public final void setGenericFilter(GenericFilter genericFilter) {
+        this.genericFilter = genericFilter;
+
+        final boolean modified = forceSupportedGenericFilter();
+
+        jCheckBoxEnabled.setSelected(genericFilter.isEnabled());
+
+        final String columnName = genericFilter.getColumnName();
+        jLabelColumnName.setText(columnName);
+
+        rangeEditors.forEach(RangeEditor::dispose);
+        rangeEditors.clear();
+        jPanelRangeEditors.removeAll();
+        for (Range range : genericFilter.getAcceptedRanges()) {
+            RangeEditor rangeEditor = new RangeEditor();
+            rangeEditor.addChangeListener(rangeEditorChangeListener);
+            rangeEditor.setAlias(columnName);
+            rangeEditor.setRange(range);
+            rangeEditor.updateRangeEditor(range, true);
+            rangeEditor.updateRangeList(null);
+            rangeEditor.setEnabled(genericFilter.isEnabled());
+            rangeEditors.add(rangeEditor);
+            jPanelRangeEditors.add(rangeEditor);
+        }
+
+        revalidate();
+
+        if (modified) {
+            fireStateChanged();
+        }
+    }
+
+    public GenericFilter getGenericFilter() {
+        return genericFilter;
+    }
+
+    private boolean forceSupportedGenericFilter() {
+        boolean modified = false;
+
+        if (!COLUMN_EFF_WAVE.equals(genericFilter.getColumnName())) {
+            genericFilter.setColumnName(COLUMN_EFF_WAVE);
+            modified = true;
+        }
+
+        if (!DataType.NUMERIC.equals(genericFilter.getDataType())) {
+            genericFilter.setDataType(DataType.NUMERIC);
+            modified = true;
+        }
+        
+        if (genericFilter.getAcceptedRanges().isEmpty()) {
+            final Range range = new Range();
+            range.setMin(0);
+            range.setMax(10);
+            genericFilter.getAcceptedRanges().add(range);
+            modified = true;
+        } else if (genericFilter.getAcceptedRanges().size() > 1) {
+            Range firstRange = genericFilter.getAcceptedRanges().remove(0);
+            genericFilter.getAcceptedRanges().clear();
+            genericFilter.getAcceptedRanges().add(firstRange);
+            modified = true;
+        }
+
+        if (!genericFilter.getAcceptedValues().isEmpty()) {
+            genericFilter.getAcceptedValues().clear();
+            modified = true;
+        }
+
+        if (modified) {
+            genericFilter.setEnabled(false);
+        }
+
+        return modified;
+    }
+
+    private void handlerEnabled() {
+        if (genericFilter != null) {
+
+            final boolean enabled = jCheckBoxEnabled.isSelected();
+
+            genericFilter.setEnabled(enabled);
+
+            for (RangeEditor rangeEditor : rangeEditors) {
+                rangeEditor.setEnabled(enabled);
+            }
+
+            fireStateChanged();
+        }
+    }
+
+    @Override
+    public void dispose() {
+        genericFilter = null;
+        for (ChangeListener listener : getChangeListeners()) {
+            removeChangeListener(listener);
+        }
+        rangeEditors.forEach(RangeEditor::dispose);
+    }
+
+    /**
+     * Listen to changes to Range.
+     *
+     * @param listener listener to notify when changes occur
+     */
+    public void addChangeListener(ChangeListener listener) {
+        listenerList.add(ChangeListener.class, listener);
+    }
+
+    /**
+     * Stop listening to changes to Range.
+     *
+     * @param listener to stop notifying when changes occur
+     */
+    public void removeChangeListener(ChangeListener listener) {
+        listenerList.remove(ChangeListener.class, listener);
+    }
+
+    /**
+     * @return the list of ChangeListeners
+     */
+    private ChangeListener[] getChangeListeners() {
+        return listenerList.getListeners(ChangeListener.class);
+    }
+
+    /**
+     * Notify listeners that changes occured to Range
+     */
+    protected void fireStateChanged() {
+        ChangeEvent event = new ChangeEvent(this);
+        for (ChangeListener changeListener : getChangeListeners()) {
+            changeListener.stateChanged(event);
+        }
+    }
+
+    private class RangeEditorChangeListener implements ChangeListener {
+        @Override
+        public void stateChanged(ChangeEvent ce) {
+            GenericFilterEditor.this.fireStateChanged();
+        }
+    }
+
+    /**
+     * This method is called from within the constructor to initialize the form. WARNING: Do NOT modify this code. The
+     * content of this method is always regenerated by the Form Editor.
+     */
+    @SuppressWarnings("unchecked")
+    // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
+    private void initComponents() {
+        java.awt.GridBagConstraints gridBagConstraints;
+
+        jCheckBoxEnabled = new javax.swing.JCheckBox();
+        jLabelColumnName = new javax.swing.JLabel();
+        jPanelRangeEditors = new javax.swing.JPanel();
+
+        setLayout(new java.awt.GridBagLayout());
+
+        jCheckBoxEnabled.setSelected(true);
+        jCheckBoxEnabled.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jCheckBoxEnabledActionPerformed(evt);
+            }
+        });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
+        add(jCheckBoxEnabled, gridBagConstraints);
+
+        jLabelColumnName.setText("COLUMN_NAME");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
+        add(jLabelColumnName, gridBagConstraints);
+
+        jPanelRangeEditors.setLayout(new javax.swing.BoxLayout(jPanelRangeEditors, javax.swing.BoxLayout.PAGE_AXIS));
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 2;
+        gridBagConstraints.gridy = 0;
+        add(jPanelRangeEditors, gridBagConstraints);
+    }// </editor-fold>//GEN-END:initComponents
+
+    private void jCheckBoxEnabledActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBoxEnabledActionPerformed
+        handlerEnabled();
+    }//GEN-LAST:event_jCheckBoxEnabledActionPerformed
+
+
+    // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.JCheckBox jCheckBoxEnabled;
+    private javax.swing.JLabel jLabelColumnName;
+    private javax.swing.JPanel jPanelRangeEditors;
+    // End of variables declaration//GEN-END:variables
+
+}

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/RangeEditor.form
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/RangeEditor.form
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<Form version="1.8" maxVersion="1.8" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
+  <NonVisualComponents>
+    <Component class="javax.swing.ButtonGroup" name="buttonGroupRangeModes">
+    </Component>
+  </NonVisualComponents>
+  <AuxValues>
+    <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
+    <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
+    <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_layoutCodeTarget" type="java.lang.Integer" value="1"/>
+    <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
+    <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,0,85,0,0,2,-109"/>
+  </AuxValues>
+
+  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
+  <SubComponents>
+    <Component class="javax.swing.JFormattedTextField" name="jFieldMin">
+      <Properties>
+        <Property name="columns" type="int" value="4"/>
+        <Property name="formatterFactory" type="javax.swing.JFormattedTextField$AbstractFormatterFactory" editor="org.netbeans.modules.form.editors.AbstractFormatterFactoryEditor">
+          <Format format="###0.####" subtype="-1" type="0"/>
+        </Property>
+        <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[30, 27]"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="actionPerformed"/>
+      </Events>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new JFormattedTextField(getNumberFieldFormatter())"/>
+      </AuxValues>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="1" anchor="10" weightX="0.3" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+    <Component class="javax.swing.JFormattedTextField" name="jFieldMax">
+      <Properties>
+        <Property name="columns" type="int" value="4"/>
+        <Property name="formatterFactory" type="javax.swing.JFormattedTextField$AbstractFormatterFactory" editor="org.netbeans.modules.form.editors.AbstractFormatterFactoryEditor">
+          <Format format="###0.####" subtype="-1" type="0"/>
+        </Property>
+        <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[30, 27]"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="actionPerformed"/>
+      </Events>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new JFormattedTextField(getNumberFieldFormatter())"/>
+      </AuxValues>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="1" gridY="0" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="1" insetsBottom="2" insetsRight="1" anchor="10" weightX="0.3" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+    <Component class="javax.swing.JComboBox" name="rangeListComboBox">
+      <Properties>
+        <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+          <StringArray count="0"/>
+        </Property>
+        <Property name="prototypeDisplayValue" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="&quot;XXXX&quot;" type="code"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="rangeListComboBoxActionPerformed"/>
+      </Events>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value=""/>
+      </AuxValues>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="2" gridY="0" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="1" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.3" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+  </SubComponents>
+</Form>

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/RangeEditor.form
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/RangeEditor.form
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <Form version="1.8" maxVersion="1.8" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
-  <NonVisualComponents>
-    <Component class="javax.swing.ButtonGroup" name="buttonGroupRangeModes">
-    </Component>
-  </NonVisualComponents>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/RangeEditor.form
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/RangeEditor.form
@@ -19,8 +19,8 @@
     <Component class="javax.swing.JFormattedTextField" name="jFieldMin">
       <Properties>
         <Property name="columns" type="int" value="4"/>
-        <Property name="formatterFactory" type="javax.swing.JFormattedTextField$AbstractFormatterFactory" editor="org.netbeans.modules.form.editors.AbstractFormatterFactoryEditor">
-          <Format format="###0.####" subtype="-1" type="0"/>
+        <Property name="formatterFactory" type="javax.swing.JFormattedTextField$AbstractFormatterFactory" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="new javax.swing.text.DefaultFormatterFactory(getNumberFieldFormatter())" type="code"/>
         </Property>
         <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
           <Dimension value="[30, 27]"/>
@@ -41,8 +41,8 @@
     <Component class="javax.swing.JFormattedTextField" name="jFieldMax">
       <Properties>
         <Property name="columns" type="int" value="4"/>
-        <Property name="formatterFactory" type="javax.swing.JFormattedTextField$AbstractFormatterFactory" editor="org.netbeans.modules.form.editors.AbstractFormatterFactoryEditor">
-          <Format format="###0.####" subtype="-1" type="0"/>
+        <Property name="formatterFactory" type="javax.swing.JFormattedTextField$AbstractFormatterFactory" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="new javax.swing.text.DefaultFormatterFactory(getNumberFieldFormatter())" type="code"/>
         </Property>
         <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
           <Dimension value="[30, 27]"/>

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/RangeEditor.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/RangeEditor.java
@@ -374,7 +374,7 @@ public class RangeEditor extends javax.swing.JPanel implements Disposable {
         setLayout(new java.awt.GridBagLayout());
 
         jFieldMin.setColumns(4);
-        jFieldMin.setFormatterFactory(new javax.swing.text.DefaultFormatterFactory(new javax.swing.text.NumberFormatter(new java.text.DecimalFormat("###0.####"))));
+        jFieldMin.setFormatterFactory(new javax.swing.text.DefaultFormatterFactory(getNumberFieldFormatter()));
         jFieldMin.setMinimumSize(new java.awt.Dimension(30, 27));
         jFieldMin.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -390,7 +390,7 @@ public class RangeEditor extends javax.swing.JPanel implements Disposable {
         add(jFieldMin, gridBagConstraints);
 
         jFieldMax.setColumns(4);
-        jFieldMax.setFormatterFactory(new javax.swing.text.DefaultFormatterFactory(new javax.swing.text.NumberFormatter(new java.text.DecimalFormat("###0.####"))));
+        jFieldMax.setFormatterFactory(new javax.swing.text.DefaultFormatterFactory(getNumberFieldFormatter()));
         jFieldMax.setMinimumSize(new java.awt.Dimension(30, 27));
         jFieldMax.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -429,7 +429,6 @@ public class RangeEditor extends javax.swing.JPanel implements Disposable {
                 if (r == null) {
                     rangeToEdit.setMin(Double.NaN);
                     jFieldMin.setValue(null);
-                    jFieldMin.requestFocus();
                 } else {
                     rangeToEdit.setMin(r.getMin());
                 }
@@ -442,7 +441,6 @@ public class RangeEditor extends javax.swing.JPanel implements Disposable {
                 if (r == null) {
                     rangeToEdit.setMax(Double.NaN);
                     jFieldMax.setValue(null);
-                    jFieldMax.requestFocus();
                 } else {
                     rangeToEdit.setMax(r.getMax());
                 }
@@ -473,7 +471,7 @@ public class RangeEditor extends javax.swing.JPanel implements Disposable {
      * @return number formatter
      */
     private static NumberFormatter getNumberFieldFormatter() {
-        final NumberFormatter nf = new NumberFormatter(new DecimalFormat("####.####")) {
+        final NumberFormatter nf = new NumberFormatter(new DecimalFormat("###0.####")) {
             /** default serial UID for Serializable interface */
             private static final long serialVersionUID = 1;
 

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/RangeEditor.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/RangeEditor.java
@@ -1,0 +1,549 @@
+/*******************************************************************************
+ * JMMC project ( http://www.jmmc.fr ) - Copyright (C) CNRS.
+ ******************************************************************************/
+package fr.jmmc.oiexplorer.core.gui;
+
+import fr.jmmc.jmal.AbsorptionLineRange;
+import fr.jmmc.jmcs.gui.component.Disposable;
+import fr.jmmc.jmcs.gui.component.GenericListModel;
+import fr.jmmc.jmcs.service.RecentValuesManager;
+import fr.jmmc.jmcs.util.NumberUtils;
+import fr.jmmc.jmcs.util.ObjectUtils;
+import fr.jmmc.oiexplorer.core.model.plot.Range;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.text.DecimalFormat;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import javax.swing.JComponent;
+import javax.swing.JFormattedTextField;
+import javax.swing.JPopupMenu;
+import javax.swing.text.NumberFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Range editor widget. has a min field, a max field, a optional list of predefined ranges.
+ */
+public class RangeEditor extends javax.swing.JPanel implements Disposable {
+
+    /**
+     * Predefined range for EFF_WAVE
+     */
+    public static final Map<String, double[]> EFF_WAVE_PREDEFINED_RANGES = new HashMap<>(11);
+    static {
+        for (AbsorptionLineRange r : AbsorptionLineRange.values()) {
+            EFF_WAVE_PREDEFINED_RANGES.put(r.getName(), new double[]{r.getMin(), r.getMax()});
+        }
+    }
+
+    /**
+     * default serial UID for Serializable interface
+     */
+    private static final long serialVersionUID = 1L;
+    /** Logger */
+    private static final Logger logger = LoggerFactory.getLogger(RangeEditor.class.getName());
+    /** undefined value for range list */
+    private static final String RANGE_NONE = "[None]";
+
+    /* members */
+
+    /**
+     * edited Range
+     */
+    private Range rangeToEdit;
+    /**
+     * predefined ranges
+     */
+    private final GenericListModel<String> rangeComboBoxModel;
+    private final Map<String, double[]> rangeList = new HashMap<>();
+
+    /**
+     * RangeEditor.UpdateListener to notify in case of modification
+     */
+    private UpdateListener parentToNotify;
+
+    /**
+     * Flag notification of associated UpdateListener
+     */
+    private boolean notify = true;
+    /** Flag indicating a user input */
+    private boolean user_input = true;
+    // recent values keys for min/max:
+    private String keyMin = null;
+    private String keyMax = null;
+    // listener references
+    private ActionListener popupListenerMin = null;
+    private ActionListener popupListenerMax = null;
+    // popup menus in action
+    private JPopupMenu popupMenuMin = null;
+    private JPopupMenu popupMenuMax = null;
+
+    /**
+     * Creates the new RangeEditor form. Use setRange() to change model to edit.
+     *
+     * @param parent UpdateListener to be notified of changes.
+     */
+    public RangeEditor(final UpdateListener parent) {
+        initComponents();
+
+        parentToNotify = parent;
+
+        rangeComboBoxModel = new GenericListModel<String>(new ArrayList<String>(10), true);
+        rangeListComboBox.setModel(rangeComboBoxModel);
+
+        jFieldMin.addPropertyChangeListener("value", new java.beans.PropertyChangeListener() {
+            @Override
+            public void propertyChange(java.beans.PropertyChangeEvent evt) {
+                if (!ObjectUtils.areEquals(evt.getOldValue(), evt.getNewValue())) {
+                    actionPerformed(new ActionEvent(jFieldMin, 0, ""));
+                }
+            }
+        });
+
+        jFieldMax.addPropertyChangeListener("value", new java.beans.PropertyChangeListener() {
+            @Override
+            public void propertyChange(java.beans.PropertyChangeEvent evt) {
+                if (!ObjectUtils.areEquals(evt.getOldValue(), evt.getNewValue())) {
+                    actionPerformed(new ActionEvent(jFieldMax, 0, ""));
+                }
+            }
+        });
+    }
+
+    /** 
+     * Creates new form AxisEditor.
+     * This empty constructor leave here for Netbeans GUI builder
+     */
+    public RangeEditor() {
+        this(null);
+    }
+
+    /**
+     * Free any ressource or reference to this instance :
+     */
+    @Override
+    public void dispose() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("RangeEditor[{}]: dispose");
+        }
+        reset();
+    }
+
+    public void reset() {
+        setRange(null, null, null);
+    }
+
+    /**
+     * Initialize widgets according to given range
+     *
+     * @param range used to initialize widget states
+     * @param keyMin alias for the popup menu history for min field
+     * @param keyMax alias for the popup menu history for max field
+     */
+    public void setRange(final Range range, final String keyMin, final String keyMax) {
+        rangeToEdit = range;
+
+        if (range == null) {
+            // reset state
+            this.keyMin = this.keyMax = null;
+            // dispose popup menus:
+            jFieldMin.setComponentPopupMenu(null);
+            jFieldMax.setComponentPopupMenu(null);
+            popupListenerMin = popupListenerMax = null;
+            popupMenuMin = popupMenuMax = null;
+            return;
+        }
+        try {
+            notify = user_input = false;
+
+            // Add popup menus to min/max fields:
+            this.keyMin = keyMin;
+            this.keyMax = keyMax;
+
+            // create new listeners to release previous listeners / popup menus:
+            popupListenerMin = new FieldSetter(jFieldMin);
+            popupListenerMax = new FieldSetter(jFieldMax);
+
+            popupMenuMin = RecentValuesManager.getMenu(keyMin, popupListenerMin);
+            popupMenuMax = RecentValuesManager.getMenu(keyMax, popupListenerMax);
+
+            // enable or disable popup menus:
+            updateRangeEditor(range, true);
+            updateRangeList(null);
+
+        } finally {
+            notify = user_input = true;
+        }
+    }
+
+    public boolean setRangeFieldValues(final Double min, final Double max) {
+        logger.debug("setRangeFieldValues: [{} - {}]", min, max);
+
+        boolean changed = false;
+        try {
+            notify = user_input = false;
+
+            changed |= setFieldValue(jFieldMin, min);
+            changed |= setFieldValue(jFieldMax, max);
+        }
+        finally {
+            notify = user_input = true;
+        }
+        return changed;
+    }
+
+    private boolean setFieldValue(final JFormattedTextField field, final double value) {
+        final Object newValue = value;
+        final Object prev = field.getValue();
+        if (ObjectUtils.areEquals(prev, newValue)) {
+            return false;
+        }
+        field.setValue(newValue);
+        return true;
+    }
+
+    public void updateRangeList(final Map<String, double[]> predefinedRanges) {
+        try {
+            this.notify = this.user_input = false;
+
+            this.rangeComboBoxModel.clear();
+            this.rangeList.clear();
+
+            if (predefinedRanges == null) {
+                rangeListComboBox.setVisible(false);
+            } else {
+                rangeListComboBox.setVisible(true);
+
+                this.rangeComboBoxModel.add(RANGE_NONE);
+                for (String rangeName : predefinedRanges.keySet()) {
+                    rangeComboBoxModel.add(rangeName);
+                }
+
+                this.rangeList.putAll(predefinedRanges);
+            }
+        }
+        finally {
+            this.notify = this.user_input = true;
+        }
+    }
+
+    private void handleRangeListSelection() {
+        if (hasRangeList()) {
+            final String selected = (String) rangeListComboBox.getSelectedItem();
+
+            double min = Double.NaN;
+            double max = Double.NaN;
+
+            if (selected != null && !selected.isEmpty() && !RANGE_NONE.equalsIgnoreCase(selected)) {
+                double[] rangeValues = rangeList.get(selected);
+                min = rangeValues[0];
+                max = rangeValues[1];
+            }
+
+            if (isFinite(min) || isFinite(max)) {
+                try {
+                    user_input = false;
+
+                    jFieldMin.setValue(Double.valueOf(min));
+                    jFieldMax.setValue(Double.valueOf(max));
+                }
+                finally {
+                    user_input = true;
+                }
+            }
+        }
+    }
+
+    /**
+     * @return true when rangeList is not empty, i.e when there exist some predefined ranges
+     */
+    private boolean hasRangeList() {
+        return !rangeList.isEmpty();
+    }
+
+    public void updateRangeEditor(final Range range, final boolean setRange) {
+        if (setRange) {
+            if (range == null) {
+                jFieldMin.setValue(null);
+                jFieldMax.setValue(null);
+            } else {
+                jFieldMin.setValue(isFinite(range.getMin()) ? Double.valueOf(range.getMin()) : null);
+                jFieldMax.setValue(isFinite(range.getMax()) ? Double.valueOf(range.getMax()) : null);
+            }
+        }
+
+        // enable or disable popup menus:
+        enablePopupMenu(jFieldMin, popupMenuMin);
+        enablePopupMenu(jFieldMax, popupMenuMax);
+    }
+
+    public Range getFieldRange() {
+        double min = Double.NaN;
+        double max = Double.NaN;
+
+        Object value = this.jFieldMin.getValue();
+
+        if (value instanceof Double) {
+            min = ((Double) value);
+        } else {
+            final Double tryMin = NumberUtils.parseDouble(jFieldMin.getText());
+            if (tryMin != null) {
+                min = tryMin;
+            }
+        }
+
+        value = this.jFieldMax.getValue();
+        if (value instanceof Double) {
+            max = ((Double) value);
+        } else {
+            final Double tryMax = NumberUtils.parseDouble(jFieldMax.getText());
+            if (tryMax != null) {
+                max = tryMax;
+            }
+        }
+
+        final boolean minFinite = isFinite(min);
+        final boolean maxFinite = isFinite(max);
+
+        Range range = null;
+
+        if ((minFinite != maxFinite)
+                || (minFinite && maxFinite && (min < max))) {
+            range = new Range();
+            range.setMin(min);
+            range.setMax(max);
+        }
+
+        // Do not store values set programmatically:
+        if (user_input) {
+            // Update recent values:
+            if (keyMin != null) {
+                RecentValuesManager.addValue(keyMin, (minFinite) ? parseField(this.jFieldMin.getFormatter(), min) : null);
+            }
+            if (keyMax != null) {
+                RecentValuesManager.addValue(keyMax, (maxFinite) ? parseField(this.jFieldMax.getFormatter(), max) : null);
+            }
+        }
+        return range;
+    }
+
+    private static String parseField(final JFormattedTextField.AbstractFormatter fmt, final double value) {
+        try {
+            return fmt.valueToString(value);
+        }
+        catch (ParseException pe) {
+            logger.info("parseField: value = {}", value, pe);
+        }
+        return Double.toString(value);
+    }
+
+    /**
+     * Return the edited Range.
+     *
+     * @return the edited Range.
+     */
+    public Range getRange() {
+        return rangeToEdit;
+    }
+
+    /**
+     * (Dis)ables the RangeEditor fields and panel
+     *
+     * @param enabled true to enable
+     */
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+        this.jFieldMin.setEnabled(enabled);
+        this.jFieldMax.setEnabled(enabled);
+        this.rangeListComboBox.setEnabled(enabled);
+    }
+
+    /** This method is called from within the constructor to
+     * initialize the form.
+     * WARNING: Do NOT modify this code. The content of this method is
+     * always regenerated by the Form Editor.
+     */
+    @SuppressWarnings("unchecked")
+    // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
+    private void initComponents() {
+        java.awt.GridBagConstraints gridBagConstraints;
+
+        buttonGroupRangeModes = new javax.swing.ButtonGroup();
+        jFieldMin = new JFormattedTextField(getNumberFieldFormatter());
+        jFieldMax = new JFormattedTextField(getNumberFieldFormatter());
+        rangeListComboBox = new javax.swing.JComboBox();
+
+        setLayout(new java.awt.GridBagLayout());
+
+        jFieldMin.setColumns(4);
+        jFieldMin.setFormatterFactory(new javax.swing.text.DefaultFormatterFactory(new javax.swing.text.NumberFormatter(new java.text.DecimalFormat("###0.####"))));
+        jFieldMin.setMinimumSize(new java.awt.Dimension(30, 27));
+        jFieldMin.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                RangeEditor.this.actionPerformed(evt);
+            }
+        });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        gridBagConstraints.weightx = 0.3;
+        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 1);
+        add(jFieldMin, gridBagConstraints);
+
+        jFieldMax.setColumns(4);
+        jFieldMax.setFormatterFactory(new javax.swing.text.DefaultFormatterFactory(new javax.swing.text.NumberFormatter(new java.text.DecimalFormat("###0.####"))));
+        jFieldMax.setMinimumSize(new java.awt.Dimension(30, 27));
+        jFieldMax.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                RangeEditor.this.actionPerformed(evt);
+            }
+        });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        gridBagConstraints.weightx = 0.3;
+        gridBagConstraints.insets = new java.awt.Insets(2, 1, 2, 1);
+        add(jFieldMax, gridBagConstraints);
+
+        rangeListComboBox.setPrototypeDisplayValue("XXXX");
+        rangeListComboBox.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                rangeListComboBoxActionPerformed(evt);
+            }
+        });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 2;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        gridBagConstraints.weightx = 0.3;
+        gridBagConstraints.insets = new java.awt.Insets(2, 1, 2, 2);
+        add(rangeListComboBox, gridBagConstraints);
+    }// </editor-fold>//GEN-END:initComponents
+
+    private void actionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_actionPerformed
+        if (evt.getSource() == jFieldMin) {
+            // only update edited range when it is Enabled:
+            if (jFieldMin.isEnabled()) {
+                final Range r = getFieldRange();
+                // update the Range
+                if (r == null) {
+                    rangeToEdit.setMin(Double.NaN);
+                    jFieldMin.setValue(Double.NaN);
+                    jFieldMin.requestFocus();
+                } else {
+                    rangeToEdit.copy(r);
+                }
+            }
+        } else if (evt.getSource() == jFieldMax) {
+            // only update edited range when it is Enabled:
+            if (jFieldMax.isEnabled()) {
+                final Range r = getFieldRange();
+                // update the Range
+                if (r == null) {
+                    rangeToEdit.setMax(Double.NaN);
+                    jFieldMax.setValue(Double.NaN);
+                    jFieldMax.requestFocus();
+                } else {
+                    rangeToEdit.copy(r);
+                }
+            }
+        } else if (evt.getSource() == rangeListComboBox) {
+            handleRangeListSelection();
+        } else {
+            throw new IllegalStateException("TODO: handle event from " + evt.getSource());
+        }
+
+        if (notify && parentToNotify != null) {
+            parentToNotify.rangeEditorUpdated();
+        }
+    }//GEN-LAST:event_actionPerformed
+
+    private void rangeListComboBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_rangeListComboBoxActionPerformed
+        RangeEditor.this.actionPerformed(evt);
+    }//GEN-LAST:event_rangeListComboBoxActionPerformed
+
+    // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.ButtonGroup buttonGroupRangeModes;
+    private javax.swing.JFormattedTextField jFieldMax;
+    private javax.swing.JFormattedTextField jFieldMin;
+    private javax.swing.JComboBox rangeListComboBox;
+    // End of variables declaration//GEN-END:variables
+
+    /**
+     * Return the custom double formatter that accepts null values
+     * @return number formatter
+     */
+    private static NumberFormatter getNumberFieldFormatter() {
+        final NumberFormatter nf = new NumberFormatter(new DecimalFormat("####.####")) {
+            /** default serial UID for Serializable interface */
+            private static final long serialVersionUID = 1;
+
+            /**
+             * Hack to allow empty string
+             */
+            @Override
+            public Object stringToValue(final String text) throws ParseException {
+                if (text == null || text.length() == 0) {
+                    return null;
+                }
+                return super.stringToValue(text);
+            }
+        };
+        nf.setValueClass(Double.class);
+        nf.setCommitsOnValidEdit(false);
+        return nf;
+    }
+
+    private static boolean isFinite(final double value) {
+        return !(Double.isNaN(value) && !Double.isInfinite(value));
+    }
+
+    private static final class FieldSetter implements ActionListener {
+
+        private final JFormattedTextField textField;
+
+        FieldSetter(final JFormattedTextField textField) {
+            this.textField = textField;
+        }
+
+        @Override
+        public void actionPerformed(final ActionEvent ae) {
+            final String value = ae.getActionCommand();
+            textField.setValue((value != null) ? Double.valueOf(value) : null);
+        }
+    }
+
+    private static void enablePopupMenu(final JComponent component, final JPopupMenu popupMenu) {
+        JPopupMenu enabledPopupMenu = null;
+        if (popupMenu != null) {
+            if (component.isEnabled() && popupMenu.getComponentCount() != 0) {
+                enabledPopupMenu = popupMenu;
+            }
+        }
+        component.setComponentPopupMenu(enabledPopupMenu);
+    }
+
+    /**
+     * @param parentToNotify the UpdateListener to set
+     */
+    public void setUpdateListener(UpdateListener parentToNotify) {
+        this.parentToNotify = parentToNotify;
+    }
+
+    /**
+     * Interface to be used by the parent object containing this RangeEditor.
+     * The parent implements the method `rangeEditorUpdated`.
+     * The RangeEditor will call `rangeEditorUpdated` when there is an update on the Range.
+     */
+    public interface UpdateListener {
+        public void rangeEditorUpdated();
+    }
+
+
+}

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/RangeEditor.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/RangeEditor.java
@@ -428,7 +428,7 @@ public class RangeEditor extends javax.swing.JPanel implements Disposable {
                 // update the Range
                 if (r == null) {
                     rangeToEdit.setMin(Double.NaN);
-                    jFieldMin.setValue(Double.NaN);
+                    jFieldMin.setValue(null);
                     jFieldMin.requestFocus();
                 } else {
                     rangeToEdit.setMin(r.getMin());
@@ -441,7 +441,7 @@ public class RangeEditor extends javax.swing.JPanel implements Disposable {
                 // update the Range
                 if (r == null) {
                     rangeToEdit.setMax(Double.NaN);
-                    jFieldMax.setValue(Double.NaN);
+                    jFieldMax.setValue(null);
                     jFieldMax.requestFocus();
                 } else {
                     rangeToEdit.setMax(r.getMax());

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/RangeEditor.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/RangeEditor.java
@@ -425,7 +425,7 @@ public class RangeEditor extends javax.swing.JPanel implements Disposable {
                     jFieldMin.setValue(Double.NaN);
                     jFieldMin.requestFocus();
                 } else {
-                    rangeToEdit.copy(r);
+                    rangeToEdit.setMin(r.getMin());
                 }
             }
         } else if (evt.getSource() == jFieldMax) {
@@ -438,7 +438,7 @@ public class RangeEditor extends javax.swing.JPanel implements Disposable {
                     jFieldMax.setValue(Double.NaN);
                     jFieldMax.requestFocus();
                 } else {
-                    rangeToEdit.copy(r);
+                    rangeToEdit.setMax(r.getMax());
                 }
             }
         } else if (evt.getSource() == rangeListComboBox) {

--- a/src/main/java/fr/jmmc/oiexplorer/core/model/OIFitsCollectionManager.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/model/OIFitsCollectionManager.java
@@ -31,8 +31,6 @@ import fr.jmmc.oiexplorer.core.model.oi.SubsetFilter;
 import fr.jmmc.oiexplorer.core.model.oi.TableUID;
 import fr.jmmc.oiexplorer.core.model.plot.PlotDefinition;
 import static fr.jmmc.oitools.OIFitsConstants.COLUMN_EFF_WAVE;
-import static fr.jmmc.oitools.image.FitsUnit.WAVELENGTH_METER;
-import static fr.jmmc.oitools.image.FitsUnit.WAVELENGTH_MICRO_METER;
 import fr.jmmc.oitools.model.OIData;
 import fr.jmmc.oitools.model.OIFitsChecker;
 import fr.jmmc.oitools.model.OIFitsCollection;
@@ -1181,10 +1179,7 @@ public final class OIFitsCollectionManager implements OIFitsCollectionManagerEve
                     }
                     // we convert every generic filter's ranges into oitools' ranges
                     for (fr.jmmc.oiexplorer.core.model.plot.Range range : genericFilter.getAcceptedRanges()) {
-                        // in the GUI ranges are expressed in micro meter, we convert them to meters
-                        final double minInMeter = WAVELENGTH_MICRO_METER.convert(range.getMin(), WAVELENGTH_METER);
-                        final double maxInMeter = WAVELENGTH_MICRO_METER.convert(range.getMax(), WAVELENGTH_METER);
-                        wavelengthRanges.add(new fr.jmmc.oitools.model.range.Range(minInMeter, maxInMeter));
+                        wavelengthRanges.add(new fr.jmmc.oitools.model.range.Range(range.getMin(), range.getMax()));
                     }
                 }
             }

--- a/src/main/java/fr/jmmc/oiexplorer/core/model/OIFitsCollectionManager.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/model/OIFitsCollectionManager.java
@@ -20,7 +20,6 @@ import fr.jmmc.oiexplorer.core.gui.OIExplorerTaskRegistry;
 import fr.jmmc.oiexplorer.core.gui.PlotInfosData;
 import fr.jmmc.oiexplorer.core.gui.selection.DataPointer;
 import fr.jmmc.oiexplorer.core.model.event.EventNotifier;
-import fr.jmmc.oiexplorer.core.model.oi.DataType;
 import fr.jmmc.oiexplorer.core.model.oi.GenericFilter;
 import fr.jmmc.oiexplorer.core.model.oi.Identifiable;
 import fr.jmmc.oiexplorer.core.model.oi.OIDataFile;
@@ -864,15 +863,16 @@ public final class OIFitsCollectionManager implements OIFitsCollectionManagerEve
 
             for (OIData oiData : oiFitsFile.getOiDataList()) {
                 logger.debug("oiData: {}", oiData);
-
-                if (remove) {
-                    oiData.removeExpressionColumn(name);
-                } else {
-                    // only compute expression on working tables:
-                    if ((working[0] && oiData instanceof OIVis)
-                            || (working[1] && oiData instanceof OIVis2)
-                            || (working[2] && oiData instanceof OIT3)) {
-                        oiData.updateExpressionColumn(name, expression);
+                if (oiData != null) {
+                    if (remove) {
+                        oiData.removeExpressionColumn(name);
+                    } else {
+                        // only compute expression on working tables:
+                        if ((working[0] && oiData instanceof OIVis)
+                                || (working[1] && oiData instanceof OIVis2)
+                                || (working[2] && oiData instanceof OIT3)) {
+                            oiData.updateExpressionColumn(name, expression);
+                        }
                     }
                 }
             }
@@ -1174,28 +1174,21 @@ public final class OIFitsCollectionManager implements OIFitsCollectionManagerEve
             }
 
             // TODO: factorize code for columns (automatize datatype, and filling of Selector)
-
-            // if the filter is about wavelength and has correct data type
             if (COLUMN_EFF_WAVE.equals(genericFilter.getColumnName())) {
-                if (DataType.NUMERIC.equals(genericFilter.getDataType())) {
-                    if (wavelengthRanges == null) {
-                        wavelengthRanges = new ArrayList<>(2);
-                    }
-                    // we convert every generic filter's ranges into oitools' ranges
-                    for (fr.jmmc.oiexplorer.core.model.plot.Range range : genericFilter.getAcceptedRanges()) {
-                        wavelengthRanges.add(new fr.jmmc.oitools.model.range.Range(range.getMin(), range.getMax()));
-                    }
+                if (wavelengthRanges == null) {
+                    wavelengthRanges = new ArrayList<>(2);
                 }
-            } // if the filter is about mjd and has correct data type
-            else if (COLUMN_MJD.equals(genericFilter.getColumnName())) {
-                if (DataType.NUMERIC.equals(genericFilter.getDataType())) {
-                    if (mjdRanges == null) {
-                        mjdRanges = new ArrayList<>(2);
-                    }
-                    // we convert every generic filter's ranges into oitools' ranges
-                    for (fr.jmmc.oiexplorer.core.model.plot.Range range : genericFilter.getAcceptedRanges()) {
-                        mjdRanges.add(new fr.jmmc.oitools.model.range.Range(range.getMin(), range.getMax()));
-                    }
+                // we convert every generic filter's ranges into oitools' ranges
+                for (fr.jmmc.oiexplorer.core.model.plot.Range range : genericFilter.getAcceptedRanges()) {
+                    wavelengthRanges.add(new fr.jmmc.oitools.model.range.Range(range.getMin(), range.getMax()));
+                }
+            } else if (COLUMN_MJD.equals(genericFilter.getColumnName())) {
+                if (mjdRanges == null) {
+                    mjdRanges = new ArrayList<>(2);
+                }
+                // we convert every generic filter's ranges into oitools' ranges
+                for (fr.jmmc.oiexplorer.core.model.plot.Range range : genericFilter.getAcceptedRanges()) {
+                    mjdRanges.add(new fr.jmmc.oitools.model.range.Range(range.getMin(), range.getMax()));
                 }
             }
         }
@@ -1222,14 +1215,12 @@ public final class OIFitsCollectionManager implements OIFitsCollectionManagerEve
                 }
             }
 
-            // set wavelength ranges from generic filters:
+            // Extra filters from generic filters:
             if (wavelengthRanges != null) {
-                selector.setWavelengthRanges(wavelengthRanges);
+                selector.addFilter(Selector.FILTER_WAVELENGTH, wavelengthRanges);
             }
-
-            // set mjd ranges from generic filters:
             if (mjdRanges != null) {
-                selector.setMJDRanges(mjdRanges);
+                selector.addFilter(Selector.FILTER_MJD, mjdRanges);
             }
 
             // Query OIData matching criteria:

--- a/src/main/java/fr/jmmc/oiexplorer/core/model/OIFitsCollectionManager.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/model/OIFitsCollectionManager.java
@@ -31,6 +31,8 @@ import fr.jmmc.oiexplorer.core.model.oi.SubsetFilter;
 import fr.jmmc.oiexplorer.core.model.oi.TableUID;
 import fr.jmmc.oiexplorer.core.model.plot.PlotDefinition;
 import static fr.jmmc.oitools.OIFitsConstants.COLUMN_EFF_WAVE;
+import static fr.jmmc.oitools.image.FitsUnit.WAVELENGTH_METER;
+import static fr.jmmc.oitools.image.FitsUnit.WAVELENGTH_MICRO_METER;
 import fr.jmmc.oitools.model.OIData;
 import fr.jmmc.oitools.model.OIFitsChecker;
 import fr.jmmc.oitools.model.OIFitsCollection;
@@ -1179,7 +1181,10 @@ public final class OIFitsCollectionManager implements OIFitsCollectionManagerEve
                     }
                     // we convert every generic filter's ranges into oitools' ranges
                     for (fr.jmmc.oiexplorer.core.model.plot.Range range : genericFilter.getAcceptedRanges()) {
-                        wavelengthRanges.add(new fr.jmmc.oitools.model.range.Range(range.getMin(), range.getMax()));
+                        // in the GUI ranges are expressed in micro meter, we convert them to meters
+                        final double minInMeter = WAVELENGTH_MICRO_METER.convert(range.getMin(), WAVELENGTH_METER);
+                        final double maxInMeter = WAVELENGTH_MICRO_METER.convert(range.getMax(), WAVELENGTH_METER);
+                        wavelengthRanges.add(new fr.jmmc.oitools.model.range.Range(minInMeter, maxInMeter));
                     }
                 }
             }


### PR DESCRIPTION
- removes Range edition code from AxisEditor
- puts it in a new class RangeEditor, having a min field, a max field, a list of predefined ranges

notes:
- to set a range to RangeEditor, we give a Range but also some alias String for the min and the max fields, in order to make the history values popup work.
- before, when you select "fixed" mode on AxisEditor, it created a null Range if no values where entered in the min max fields. Now, it always creates a Range(NaN,NaN) at least. Because it works better with the RangeEditor which is meant to edit an actual Range, not a null value.
- the parent listener has been modified to be expressed by Swing ChangeListener
- predefined ranges for wavelength have been moved to a static map in RangeEditor.
- getFieldRange has been modified to accept "0", "1", "2" input (that is considered as a Long and thus was refused)
