### PR TITLE
wavelength mask in oifitsbrowser data panel

### DIFF
--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/FitsTableViewerPanel.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/FitsTableViewerPanel.java
@@ -18,9 +18,11 @@ import fr.jmmc.oitools.model.OIData;
 import fr.jmmc.oitools.processing.SelectorResult;
 import java.awt.Color;
 import java.awt.Component;
+import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JTable;
 import javax.swing.UIManager;
+import javax.swing.border.Border;
 import javax.swing.event.TableModelEvent;
 import javax.swing.event.TableModelListener;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -39,7 +41,7 @@ public final class FitsTableViewerPanel extends javax.swing.JPanel {
     private static final Logger logger = LoggerFactory.getLogger(FitsTableViewerPanel.class.getName());
 
     // colors for table cell rendering. we need to register the default colors.
-    private static final Color COLOR_MASKED = new Color(244, 244, 215);
+    private static final Color COLOR_MASKED = Color.YELLOW;
     private static final Color COLOR_SELECTED
                                = (UIManager.getColor("Table.selectionBackground") == null)
             ? new Color(173, 216, 230)
@@ -304,6 +306,9 @@ public final class FitsTableViewerPanel extends javax.swing.JPanel {
         /** default serial UID for Serializable interface */
         private static final long serialVersionUID = 1;
 
+        /** orange border for selected cell */
+        private final Border _orangeBorder = BorderFactory.createLineBorder(Color.ORANGE, 2);
+
         private TableCellNumberMaskRenderer() {
             super();
         }
@@ -336,8 +341,10 @@ public final class FitsTableViewerPanel extends javax.swing.JPanel {
         public Component getTableCellRendererComponent(
                 JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
 
-            final Component component
-                            = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+
+            // always use right alignment:
+            setHorizontalAlignment(JLabel.RIGHT);
 
             Color bgColor = COLOR_NORMAL;
 
@@ -382,8 +389,12 @@ public final class FitsTableViewerPanel extends javax.swing.JPanel {
                     }
                 }
             }
-            component.setBackground(bgColor);
-            return component;
+
+            if (bgColor == COLOR_MASKED) {
+                setBorder(_orangeBorder);
+            }
+            setBackground(bgColor);
+            return this;
         }
     }
 }

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/OIFitsTableBrowser.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/OIFitsTableBrowser.java
@@ -25,7 +25,6 @@ import fr.jmmc.oitools.model.OIData;
 import fr.jmmc.oitools.model.OIFitsFile;
 import fr.jmmc.oitools.model.OIFitsLoader;
 import fr.jmmc.oitools.model.OITable;
-import fr.jmmc.oitools.model.OIWavelength;
 import fr.jmmc.oitools.processing.SelectorResult;
 import fr.nom.tam.fits.FitsException;
 import java.awt.Dimension;
@@ -57,9 +56,9 @@ public final class OIFitsTableBrowser extends javax.swing.JPanel implements OIFi
     /** table viewer panel */
     private final FitsTableViewerPanel tableViewer;
     /** oifits (weak) file reference */
-    private WeakReference<OIFitsFile> oiFitsFileRef = null;
+    private transient WeakReference<OIFitsFile> oiFitsFileRef = null;
     /** selectorResult (weak) reference */
-    private WeakReference<SelectorResult> selectorResultRef = null;
+    private transient WeakReference<SelectorResult> selectorResultRef = null;
 
     /** Creates new form FitsBrowserPanel */
     public OIFitsTableBrowser() {
@@ -288,19 +287,18 @@ public final class OIFitsTableBrowser extends javax.swing.JPanel implements OIFi
             }
             logger.debug("hdu: {}", hdu);
 
+            final SelectorResult selectorResult;
             if (hdu != null && hdu instanceof OIData) {
-                final SelectorResult selectorResult = (selectorResultRef == null) ? null : selectorResultRef.get();
-                if (selectorResult != null) {
-                    final OIWavelength oiWavelength = ((OIData) hdu).getOiWavelength();
-                    wavelengthMask = selectorResult.getWavelengthMaskNotFull(oiWavelength);
-                }
+                selectorResult = (selectorResultRef == null) ? null : selectorResultRef.get();
+            } else {
+                selectorResult = null;
             }
 
             final boolean includeDerivedColumns = true;
             final boolean expandRows = isTableRowsExpanded(hdu);
 
             this.tableViewer.setViewerOptions(includeDerivedColumns, expandRows);
-            this.tableViewer.setHdu(hdu, wavelengthMask);
+            this.tableViewer.setHdu(hdu, selectorResult);
         }
     }
 

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/OIFitsTableBrowser.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/OIFitsTableBrowser.java
@@ -275,11 +275,9 @@ public final class OIFitsTableBrowser extends javax.swing.JPanel implements OIFi
 
             // lazy resolve HDU:
             final OIFitsFile oiFitsFile = getOIFitsFile();
-            final FitsHDU hdu;
-            IndexMask wavelengthMask = null; // null means we mask nothing
-
             logger.debug("oiFitsFile: {}", oiFitsFile);
 
+            final FitsHDU hdu;
             if (oiFitsFile == null) {
                 hdu = null;
             } else {

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/PlotView.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/PlotView.java
@@ -11,6 +11,7 @@ import fr.jmmc.oiexplorer.core.model.OIFitsCollectionManagerEventListener;
 import fr.jmmc.oiexplorer.core.model.OIFitsCollectionManagerEventType;
 import fr.jmmc.oiexplorer.core.model.oi.SubsetDefinition;
 import fr.jmmc.oitools.model.OIFitsFile;
+import fr.jmmc.oitools.processing.SelectorResult;
 import java.lang.ref.WeakReference;
 import javax.swing.JPanel;
 import org.slf4j.Logger;
@@ -121,7 +122,12 @@ public class PlotView extends javax.swing.JPanel implements OIFitsCollectionMana
             final OIFitsFile oiFitsFile = (subsetDefinition != null) ? subsetDefinition.getOIFitsSubset() : null;
 
             if (oiFitsBrowserPanel != null) {
-                this.oiFitsBrowserPanel.setOiFitsFileRef(new WeakReference<OIFitsFile>(oiFitsFile));
+
+                final SelectorResult selectorResult
+                        = (subsetDefinition == null) ? null : subsetDefinition.getSelectorResult();
+
+                this.oiFitsBrowserPanel.setOiFitsFileRef(
+                        new WeakReference<OIFitsFile>(oiFitsFile), new WeakReference<SelectorResult>(selectorResult));
             }
             if (oiFitsHtmlPanel != null) {
                 this.oiFitsHtmlPanel.updateOIFits(oiFitsFile);

--- a/src/main/java/fr/jmmc/oiexplorer/core/gui/model/ColumnsTableModel.java
+++ b/src/main/java/fr/jmmc/oiexplorer/core/gui/model/ColumnsTableModel.java
@@ -35,7 +35,7 @@ public final class ColumnsTableModel extends AbstractTableModel {
 
     /* members */
     /** FITS table (weak) reference */
-    private WeakReference<FitsTable> tableRef = null;
+    private transient WeakReference<FitsTable> tableRef = null;
     /** flag to include derived columns */
     private boolean includeDerivedColumns = true;
     /** flag to expand or not arrays (2D only) as columns */
@@ -43,7 +43,7 @@ public final class ColumnsTableModel extends AbstractTableModel {
     /** flag to expand or not arrays (2D only) as columns  (deprecated ?) */
     private boolean expandArrays = false;
     /** column mapping */
-    private final ArrayList<ColumnMapping> columnMap = new ArrayList<ColumnMapping>();
+    private final ArrayList<ColumnMapping> columnMap = new ArrayList<ColumnMapping>(16);
     /** column dimensions */
     private final int[] columnDims2d = new int[2]; // 2d max
     /** number of (virtual) rows */


### PR DESCRIPTION
This PR colors the masked rows in table panel when a wavelength filter is active. It only does it for Views tab and not for Browser tabs in OIExplorer.

- OIFItsTableBrowser receives an optional weak reference to SelectorResult (in addition of a reference to OIFitsFile). It permits him to read eventual masks.
- when a table is selected in OIFitsTableBrowser, if it is an OIData it tries to find an eventual wavelength mask associated
- in FItsTableViewerPanel, the Cell Renderer now uses an optional given wavelength mask to filter the rows